### PR TITLE
Upgrade to Spring Security 5 RC1

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -11,10 +11,16 @@
     <name>notes</name>
     <description>Notes Server with Kotlin and Spring Boot</description>
 
-    <parent>
+    <!--<parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>1.5.6.RELEASE</version>
+        <relativePath/> &lt;!&ndash; lookup parent from repository &ndash;&gt;
+    </parent>-->
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.0.0.BUILD-SNAPSHOT</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -23,7 +29,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
-        <kotlin.version>1.1.3-2</kotlin.version>
+        <spring-security.version>5.0.0.RC1</spring-security.version>
     </properties>
 
     <dependencies>
@@ -41,18 +47,16 @@
         </dependency>
         <dependency>
             <groupId>com.okta.spring</groupId>
-            <artifactId>okta-spring-security-starter</artifactId>
-            <version>0.1.0</version>
+            <artifactId>okta-spring-boot-starter</artifactId>
+            <version>0.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib-jre8</artifactId>
-            <version>${kotlin.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-reflect</artifactId>
-            <version>${kotlin.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -76,16 +80,6 @@
         </dependency>
     </dependencies>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.springframework.security.oauth</groupId>
-                <artifactId>spring-security-oauth2</artifactId>
-                <version>2.2.0.RELEASE</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <build>
         <defaultGoal>spring-boot:run</defaultGoal>
         <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
@@ -98,29 +92,11 @@
             <plugin>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <groupId>org.jetbrains.kotlin</groupId>
-                <version>${kotlin.version}</version>
                 <configuration>
                     <compilerPlugins>
                         <plugin>spring</plugin>
                     </compilerPlugins>
-                    <jvmTarget>1.8</jvmTarget>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>compile</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>test-compile</id>
-                        <phase>test-compile</phase>
-                        <goals>
-                            <goal>test-compile</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <dependencies>
                     <dependency>
                         <groupId>org.jetbrains.kotlin</groupId>
@@ -131,4 +107,42 @@
             </plugin>
         </plugins>
     </build>
+    
+  	<repositories>
+  		<repository>
+  			<id>spring-snapshots</id>
+  			<name>Spring Snapshots</name>
+  			<url>https://repo.spring.io/snapshot</url>
+  			<snapshots>
+  				<enabled>true</enabled>
+  			</snapshots>
+  		</repository>
+  		<repository>
+  			<id>spring-milestones</id>
+  			<name>Spring Milestones</name>
+  			<url>https://repo.spring.io/milestone</url>
+  			<snapshots>
+  				<enabled>false</enabled>
+  			</snapshots>
+  		</repository>
+  	</repositories>
+
+  	<pluginRepositories>
+  		<pluginRepository>
+  			<id>spring-snapshots</id>
+  			<name>Spring Snapshots</name>
+  			<url>https://repo.spring.io/snapshot</url>
+  			<snapshots>
+  				<enabled>true</enabled>
+  			</snapshots>
+  		</pluginRepository>
+  		<pluginRepository>
+  			<id>spring-milestones</id>
+  			<name>Spring Milestones</name>
+  			<url>https://repo.spring.io/milestone</url>
+  			<snapshots>
+  				<enabled>false</enabled>
+  			</snapshots>
+  		</pluginRepository>
+  	</pluginRepositories>
 </project>

--- a/server/src/main/kotlin/com/okta/developer/notes/NotesApplication.kt
+++ b/server/src/main/kotlin/com/okta/developer/notes/NotesApplication.kt
@@ -28,7 +28,7 @@ import javax.persistence.Id
 class NotesApplication {
 
     @Bean
-    fun simpleCorsFilter(): FilterRegistrationBean {
+    fun simpleCorsFilter(): FilterRegistrationBean<CorsFilter> {
         val source = UrlBasedCorsConfigurationSource()
         val config = CorsConfiguration()
         config.allowCredentials = true

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -1,3 +1,3 @@
-okta.oauth.issuer=https://dev-158606.oktapreview.com/oauth2/default
-okta.oauth.audience=api://default
-okta.oauth.clientId=0oabl213xlbMjGJYo0h7
+okta.oauth2.issuer=https://dev-158606.oktapreview.com/oauth2/default
+okta.oauth2.audience=api://default
+okta.oauth2.clientId=0oabl213xlbMjGJYo0h7


### PR DESCRIPTION
After upgrading to Spring Security 5, it seems like the Okta Spring Boot Starter isn't working. With the previous version, I was given an error message when I hit localhost:8080.

<img width="868" alt="screen shot 2017-11-01 at 5 13 27 pm" src="https://user-images.githubusercontent.com/17892/32302399-1c94afba-bf28-11e7-8e7e-74465a065b45.png">

Now I get prompted with a login screen. 

<img width="868" alt="screen shot 2017-11-01 at 5 14 05 pm" src="https://user-images.githubusercontent.com/17892/32302400-1cb21960-bf28-11e7-9de3-9547331b8ea4.png">

Any ideas @bdemers?
